### PR TITLE
Collect color constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,9 +13,15 @@ export class Constants {
     public static readonly DEFAULT_VALUE_BOX_TEXT_PADDING = 4;
     public static readonly DEFAULT_VALUE_BOX_MARGIN_LEFT = 8;
 
+    public static readonly TEAL = "32, 116, 120"; // rgb(32, 116, 120)
+    public static readonly LIGHT_GREEN = "162, 161, 35"; // rgb(162, 161, 35)
+    public static readonly RED = "156, 36, 35"; // rgb(156, 36, 35)
     public static readonly BLUE = "78, 117, 142"; // rgb(78, 117, 142)
     public static readonly GREEN = "92, 154, 87"; // rgb(92, 154, 87)
     public static readonly PURPLE = "109, 19, 132"; // rgb(109, 19, 132)
+    public static readonly DARK_BLUE = '19, 42, 79'; // rgb(19, 42, 79)
+    public static readonly YELLOW_BROWN = '138, 108, 19'; // rgb(138, 108, 19)
+
     public static readonly DEFAULT_FUNC_BACKGROUND_COLOR = Constants.BLUE;
     public static readonly DEFAULT_FUNC_PURE_BACKGROUND_COLOR = Constants.GREEN;
     public static readonly DEFAULT_FUNC_ENTRY_BACKGROUND_COLOR = Constants.PURPLE;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,9 +13,12 @@ export class Constants {
     public static readonly DEFAULT_VALUE_BOX_TEXT_PADDING = 4;
     public static readonly DEFAULT_VALUE_BOX_MARGIN_LEFT = 8;
 
-    public static readonly DEFAULT_FUNC_BACKGROUND_COLOR = '78, 117, 142';
-    public static readonly DEFAULT_FUNC_PURE_BACKGROUND_COLOR = '92, 154, 87';
-    public static readonly DEFAULT_FUNC_ENTRY_BACKGROUND_COLOR = '109, 19, 132';
+    public static readonly BLUE = "78, 117, 142"; // rgb(78, 117, 142)
+    public static readonly GREEN = "92, 154, 87"; // rgb(92, 154, 87)
+    public static readonly PURPLE = "109, 19, 132"; // rgb(109, 19, 132)
+    public static readonly DEFAULT_FUNC_BACKGROUND_COLOR = Constants.BLUE;
+    public static readonly DEFAULT_FUNC_PURE_BACKGROUND_COLOR = Constants.GREEN;
+    public static readonly DEFAULT_FUNC_ENTRY_BACKGROUND_COLOR = Constants.PURPLE;
 
     public static readonly DEFAULT_BOX_HEIGHT = 16;
     public static readonly DEFAULT_BOX_RADIUS = 2;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@
 export class Constants {
     public static readonly NODE_FONT = "12px sans-serif";
     public static readonly NODE_HEADER_FONT = "bold 12px sans-serif";
-    public static readonly NODE_BACKGROUND_COLOR = "rgba(15,15,15,0.6)";
+    public static readonly BLACK = "rgba(15,15,15,0.6)";
+    public static readonly NODE_BACKGROUND_COLOR = Constants.BLACK;
     public static readonly NODE_TEXT_COLOR = "rgb(240,240,240)";
     public static readonly NODE_SUBTITLE_COLOR = "rgb(170,170,170)";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export class Constants {
     public static readonly BLUE = "78, 117, 142"; // rgb(78, 117, 142)
     public static readonly GREEN = "92, 154, 87"; // rgb(92, 154, 87)
     public static readonly PURPLE = "109, 19, 132"; // rgb(109, 19, 132)
+    public static readonly BROWN = "175, 107, 43"; // rgb(175, 107, 43)
     public static readonly DARK_BLUE = '19, 42, 79'; // rgb(19, 42, 79)
     public static readonly YELLOW_BROWN = '138, 108, 19'; // rgb(138, 108, 19)
 

--- a/src/controls/header.ts
+++ b/src/controls/header.ts
@@ -14,7 +14,7 @@ import { PinControl } from "./pin.control";
 export class Header extends HorizontalPanel {
 
     private static readonly HEADER_TITLE_HEIGHT = 23;
-    private static readonly NODE_DEFAULT_BACKGROUND_COLOR = '78, 117, 142';
+    private static readonly NODE_DEFAULT_BACKGROUND_COLOR = Constants.BLUE;
 
     private fillStyleHeader: CanvasGradient;
     protected headerHeight = Header.HEADER_TITLE_HEIGHT;

--- a/src/controls/nodes/headless-node-control.ts
+++ b/src/controls/nodes/headless-node-control.ts
@@ -8,7 +8,7 @@ import { HorizontalSpacerControl } from "../horizontal-spacer.control";
 
 export class HeadlessNodeControl extends NodeControl {
 
-    private static readonly _NODE_BACKGROUND_COLOR = "rgba(15,15,15,0.6)";
+    private static readonly _NODE_BACKGROUND_COLOR = Constants.BLACK;
 
     constructor(node: Node) {
         super(node);

--- a/src/parser/node-parsers/custom-event-node.parser.ts
+++ b/src/parser/node-parsers/custom-event-node.parser.ts
@@ -6,6 +6,7 @@ import { ReplicationType } from "../../data/replication-type";
 import { BlueprintParserUtils } from "../blueprint-parser-utils";
 import { NodeParser } from "../node.parser";
 import { ParsingNodeData } from "../parsing-node-data";
+import { Constants } from "../../constants";
 
 
 /*
@@ -40,7 +41,7 @@ export class CustomEventNodeParser extends NodeParser {
         [ReplicationType.RunOnOwningClient]: 'Executes On Owning Client',
     }
 
-    private static readonly _DEFAULT_BACKGROUND_COLOR = '156, 36, 35';
+    private static readonly _DEFAULT_BACKGROUND_COLOR = Constants.RED;
 
     constructor() {
         super({

--- a/src/parser/node-parsers/dynamic-cast-node.parser.ts
+++ b/src/parser/node-parsers/dynamic-cast-node.parser.ts
@@ -6,6 +6,7 @@ import { BlueprintParserUtils } from "../blueprint-parser-utils";
 import { NodeDataReferenceParser } from "../node-data-reference.parser";
 import { NodeParser } from "../node.parser";
 import { ParsingNodeData } from "../parsing-node-data";
+import { Constants } from "../../constants";
 
 
 export class DynamicCastNodeParser extends NodeParser {
@@ -23,7 +24,7 @@ export class DynamicCastNodeParser extends NodeParser {
 
         let castNode = (data.node as DynamicCastNode);
         castNode.title = "Cast to " + castNode.targetType.className;
-        castNode.backgroundColor = "32, 116, 120";
+        castNode.backgroundColor = Constants.TEAL;
         
 
         return new HeadedNodeControl(data.node, IconLibrary.CAST);

--- a/src/parser/node-parsers/event-node.parser.ts
+++ b/src/parser/node-parsers/event-node.parser.ts
@@ -6,12 +6,10 @@ import { BlueprintParserUtils } from "../blueprint-parser-utils";
 import { NodeDataReferenceParser } from "../node-data-reference.parser";
 import { NodeParser } from "../node.parser";
 import { ParsingNodeData } from "../parsing-node-data";
+import { Constants } from "../../constants";
 
 
 export class EventNodeParser extends NodeParser {
-
-    private static readonly _DEFAULT_BACKGROUND_COLOR = '156, 36, 35';
-
     constructor() {
         super({
             "EventReference": (node: EventNode, value: string) => {
@@ -25,7 +23,7 @@ export class EventNodeParser extends NodeParser {
 
     public parse(data: ParsingNodeData): NodeControl {
         this.parseProperties(data);
-        data.node.backgroundColor = EventNodeParser._DEFAULT_BACKGROUND_COLOR;
+        data.node.backgroundColor = Constants.RED;
         BlueprintParserUtils.configureFirstDelegatePinInHead(data.node.customProperties);
         return new HeadedNodeControl(data.node, IconLibrary.EVENT);
     }

--- a/src/parser/node-parsers/input-axis-node.parser.ts
+++ b/src/parser/node-parsers/input-axis-node.parser.ts
@@ -5,10 +5,11 @@ import { InputAxisNode } from "../../data/nodes/input-axis.node";
 import { BlueprintParserUtils } from "../blueprint-parser-utils";
 import { NodeParser } from "../node.parser";
 import { ParsingNodeData } from "../parsing-node-data";
+import { Constants } from "../../constants";
 
 export class InputAxisNodeParser extends NodeParser {
 
-    private static readonly _DEFAULT_BACKGROUND_COLOR = '156, 36, 35';
+    private static readonly _DEFAULT_BACKGROUND_COLOR = Constants.RED;
 
     constructor() {
         super({

--- a/src/parser/node-parsers/input-key-node.parser.ts
+++ b/src/parser/node-parsers/input-key-node.parser.ts
@@ -5,11 +5,12 @@ import { InputKeyNode } from "../../data/nodes/input-key.node";
 import { prettifyText } from "../../utils/text-utils";
 import { NodeParser } from "../node.parser";
 import { ParsingNodeData } from "../parsing-node-data";
+import { Constants } from "../../constants";
 
 
 export class InputKeyNodeParser extends NodeParser {
 
-    private static readonly DEFAULT_BACKGROUND_COLOR = '156, 36, 35';
+    private static readonly DEFAULT_BACKGROUND_COLOR = Constants.RED;
 
     constructor() {
         super({

--- a/src/parser/node-parsers/input-touch-node.parser.ts
+++ b/src/parser/node-parsers/input-touch-node.parser.ts
@@ -4,10 +4,11 @@ import { IconLibrary } from "../../controls/utils/icon-library";
 import { InputAxisNode } from "../../data/nodes/input-axis.node";
 import { NodeParser } from "../node.parser";
 import { ParsingNodeData } from "../parsing-node-data";
+import { Constants } from "../../constants";
 
 export class InputTouchNodeParser extends NodeParser {
 
-    private static readonly _DEFAULT_BACKGROUND_COLOR = '156, 36, 35';
+    private static readonly _DEFAULT_BACKGROUND_COLOR = Constants.RED;
 
     public parse(data: ParsingNodeData): NodeControl {
         data.node.title = "Input Touch";

--- a/src/parser/node-parsers/struct-node.parser.ts
+++ b/src/parser/node-parsers/struct-node.parser.ts
@@ -6,10 +6,11 @@ import { ParsingNodeData } from "../parsing-node-data";
 import { NodeDataReferenceParser } from "../node-data-reference.parser";
 import { StructNode } from "../../data/nodes/struct.node";
 import { UnrealNodeClass } from "../../data/classes/unreal-node-class";
+import { Constants } from "../../constants";
 
 export class StructNodeParser extends NodeParser {
 
-    private static readonly _DEFAULT_BACKGROUND_COLOR = '19, 42, 79';
+    private static readonly _DEFAULT_BACKGROUND_COLOR = Constants.DARK_BLUE;
 
     constructor() {
         super({

--- a/src/parser/node-parsers/switch-enum-node.parser.ts
+++ b/src/parser/node-parsers/switch-enum-node.parser.ts
@@ -7,6 +7,7 @@ import { SwitchEnumNode } from "../../data/nodes/switch-enum.node";
 import { BlueprintParserUtils } from "../blueprint-parser-utils";
 import { NodeParser } from "../node.parser";
 import { ParsingNodeData } from "../parsing-node-data";
+import { Constants } from "../../constants";
 
 
 export class SwitchEnumNodeParser extends NodeParser {
@@ -28,7 +29,7 @@ export class SwitchEnumNodeParser extends NodeParser {
 
         let switchNode = (data.node as SwitchEnumNode);
         switchNode.title = "Switch on " + BlueprintParserUtils.getClassFriendlyName(switchNode.enum);
-        switchNode.backgroundColor = "162, 161, 35";
+        switchNode.backgroundColor = Constants.LIGHT_GREEN;
         
         return new FoldableHeadedNodeControl(data.node, IconLibrary.SWITCH);
     }

--- a/src/parser/node-parsers/timeline-node.parser.ts
+++ b/src/parser/node-parsers/timeline-node.parser.ts
@@ -5,11 +5,12 @@ import { Node } from "../../data/nodes/node";
 import { BlueprintParserUtils } from "../blueprint-parser-utils";
 import { NodeParser } from "../node.parser";
 import { ParsingNodeData } from "../parsing-node-data";
+import { Constants } from "../../constants";
 
 
 export class TimelineNodeParser extends NodeParser {
 
-    private static readonly DEFAULT_BACKGROUND_COLOR = '138, 108, 19';
+    private static readonly DEFAULT_BACKGROUND_COLOR = Constants.YELLOW_BROWN;
 
     constructor() {
         super({


### PR DESCRIPTION
Collect some color constants in the same place, for easy reuse.
Added some `// rgb(1, 2, 3)` comments, for IDEs that display the actual color inline, so it is easy to see.

I named the color constants with the name of the color, so it is easy to tell which color is being used in any location.