### PR TITLE
Add pin types

### DIFF
--- a/src/controls/utils/color-utils.ts
+++ b/src/controls/utils/color-utils.ts
@@ -13,7 +13,7 @@ export enum StructClass {
 export class ColorUtils {
 
     public static getPinColor(pin: PinProperty): string {
-        return this.getPinColorByCategory(pin.category, pin.subCategoryObject.class);
+        return this.getPinColorByCategory(pin.category, pin.subCategoryObject?.class);
     }
 
     public static getPinColorByCategory(category: PinCategory, subCategoryObject?: string): string {

--- a/src/controls/utils/color-utils.ts
+++ b/src/controls/utils/color-utils.ts
@@ -23,6 +23,7 @@ export class ColorUtils {
             case PinCategory.bool:
                 return 'rgb(146, 1, 1)';
             case PinCategory.float:
+            case PinCategory.real:
                 return 'rgb(158, 250, 68)';
             case PinCategory.int:
                 return 'rgb(30, 226, 174)';

--- a/src/data/pin/pin-category.ts
+++ b/src/data/pin/pin-category.ts
@@ -8,6 +8,7 @@ export enum PinCategory {
     string = "string",
     text = "text",
     float = "float",
+    real = "real",
     struct = "struct",
     class = "class",
     bool = "bool",

--- a/src/data/pin/pin-property.ts
+++ b/src/data/pin/pin-property.ts
@@ -27,6 +27,7 @@ export class PinProperty extends CustomProperty {
     isConst: boolean;
     isWeakPointer: boolean;
     isUObjectWrapper: boolean;
+    serializeAsSinglePrecisionFloat: boolean;
 
     linkedTo: PinLink[];
     persistentGUID: string;

--- a/src/data/pin/pin-property.ts
+++ b/src/data/pin/pin-property.ts
@@ -51,6 +51,7 @@ export class PinProperty extends CustomProperty {
     hideName: boolean;
     showInHead: boolean;
     subPins: string;
+    parentPin: string;
 
     constructor(nodeName: string) {
         super();

--- a/src/data/pin/pin-property.ts
+++ b/src/data/pin/pin-property.ts
@@ -50,6 +50,7 @@ export class PinProperty extends CustomProperty {
 
     hideName: boolean;
     showInHead: boolean;
+    subPins: string;
 
     constructor(nodeName: string) {
         super();

--- a/src/parser/node-parsers/call-function-node.parser.ts
+++ b/src/parser/node-parsers/call-function-node.parser.ts
@@ -26,6 +26,7 @@ export class CallFunctionNodeParser extends NodeParser {
     constructor() {
         super({
             "bIsPureFunc": (node: CallFunctionNode, value: string) => { node.isPureFunc = (value === "True"); },
+            "bDefaultsToPureFunc": (node: CallFunctionNode, value: string) => { node.isPureFunc = (value === "True"); },
             "bIsConstFunc": (node: CallFunctionNode, value: string) => { node.isConstFunc = (value === "True"); },
             "FunctionReference": (node: CallFunctionNode, value: string) => {
                 const parser = new NodeDataReferenceParser();

--- a/src/parser/node-parsers/generic-node.parser.ts
+++ b/src/parser/node-parsers/generic-node.parser.ts
@@ -84,6 +84,7 @@ export class GenericNodeParser extends NodeParser {
         [key: string]: () => CustomPropertyParser
     } = {
         "Pin": () => new PinPropertyParser(),
+        "UserDefinedPin": () => new PinPropertyParser(),
     }
 
     constructor() {
@@ -162,7 +163,8 @@ export class GenericNodeParser extends NodeParser {
                 data.node.customProperties.push(property);
 
                 if (property instanceof PinProperty) {
-                    if ((property as PinProperty).subCategoryObject.class === StructClass.LatentActionInfo) {
+                    const pinProp = property as PinProperty;
+                    if (pinProp.subCategoryObject && pinProp.subCategoryObject.class === StructClass.LatentActionInfo) {
                         data.node.latent = true;
                     }
                 }

--- a/src/parser/pin-property.parser.ts
+++ b/src/parser/pin-property.parser.ts
@@ -223,6 +223,11 @@ export class PinPropertyParser implements CustomPropertyParser {
                         key = lastValue;
                         args[key] = value;
                     }
+                } else if (prop.startsWith("INVTEXT")) {
+                    const invtextMatch = prop.match(/INVTEXT\("([^"]*)"\)/);
+                    if (invtextMatch && (index + offset) % 2 == 1) {
+                        args[namingkKey] = invtextMatch[1];
+                    }
                 } else {
                     if ((index + offset) % 2 == 0) {
                         namingkKey = prop.replace(/"/g, '');

--- a/src/parser/pin-property.parser.ts
+++ b/src/parser/pin-property.parser.ts
@@ -75,6 +75,9 @@ export class PinPropertyParser implements CustomPropertyParser {
         "PinType.bSerializeAsSinglePrecisionFloat": (p: PinProperty, value: string) => {
             p.serializeAsSinglePrecisionFloat = value.toLowerCase() === "true";
         },
+        "SubPins": (p: PinProperty, value: string) => {
+            p.subPins = value;
+        },
     }
 
     parse(propertyData: string, nodeName: string): PinProperty {

--- a/src/parser/pin-property.parser.ts
+++ b/src/parser/pin-property.parser.ts
@@ -26,6 +26,7 @@ export class PinPropertyParser implements CustomPropertyParser {
         "PinFriendlyName": (p: PinProperty, value: string) => { p.friendlyName = prettifyText(PinPropertyParser.parsePinFriendlyName(value)); },
         "PinType.PinCategory": (p: PinProperty, value: string) => { p.category = PinPropertyParser.parsePinCategory(value); },
         "Direction": (p: PinProperty, value: string) => { p.direction = PinPropertyParser.parseDirection(value); },
+        "DesiredPinDirection": (p: PinProperty, value: string) => { p.direction = PinPropertyParser.parseDirection(value); },
         "PinToolTip": (p: PinProperty, value: string) => { p.toolTip = BlueprintParserUtils.parseString(value); },
         "PinType.PinSubCategory": (p: PinProperty, value: string) => { p.subCategory = BlueprintParserUtils.parseString(value); },
         "PinType.PinSubCategoryObject": (p: PinProperty, value: string) => { p.subCategoryObject = PinPropertyParser.parseSubCategoryObject(value); },

--- a/src/parser/pin-property.parser.ts
+++ b/src/parser/pin-property.parser.ts
@@ -317,6 +317,16 @@ export class PinPropertyParser implements CustomPropertyParser {
                 color.applyGamma();
                 return { control: ColorBoxControl, data: color};
             default:
+                if (subCategoryObject.includes('LinearColor')) {
+                    const cParams = this.parseDefaultValueStructCommon(value).map(p => Number(p.value));
+                    const color = new Color(
+                        (cParams[0] || 0) * 255,
+                        (cParams[1] || 0) * 255,
+                        (cParams[2] || 0) * 255,
+                        cParams[3]);
+                    color.applyGamma();
+                    return { control: ColorBoxControl, data: color};
+                }
                 return { control: StructBoxControl, data: this.parseDefaultValueStructCommon(value) };
         }
     }

--- a/src/parser/pin-property.parser.ts
+++ b/src/parser/pin-property.parser.ts
@@ -72,6 +72,9 @@ export class PinPropertyParser implements CustomPropertyParser {
             //     console.log(`Found interesting attribute 'PinType.PinSubCategoryMemberReference' for which a value other than '()' was set. PinType.PinSubCategoryMemberReference='${value}' [pin-name: ${p.name}]`);
             // }
         },
+        "PinType.bSerializeAsSinglePrecisionFloat": (p: PinProperty, value: string) => {
+            p.serializeAsSinglePrecisionFloat = value.toLowerCase() === "true";
+        },
     }
 
     parse(propertyData: string, nodeName: string): PinProperty {

--- a/src/parser/pin-property.parser.ts
+++ b/src/parser/pin-property.parser.ts
@@ -78,6 +78,9 @@ export class PinPropertyParser implements CustomPropertyParser {
         "SubPins": (p: PinProperty, value: string) => {
             p.subPins = value;
         },
+        "ParentPin": (p: PinProperty, value: string) => {
+            p.parentPin = BlueprintParserUtils.parseString(value);
+        },
     }
 
     parse(propertyData: string, nodeName: string): PinProperty {

--- a/src/parser/pin-property.parser.ts
+++ b/src/parser/pin-property.parser.ts
@@ -25,6 +25,13 @@ export class PinPropertyParser implements CustomPropertyParser {
         "PinName": (p: PinProperty, value: string) => { p.name = prettifyText(BlueprintParserUtils.parseString(value)); },
         "PinFriendlyName": (p: PinProperty, value: string) => { p.friendlyName = prettifyText(PinPropertyParser.parsePinFriendlyName(value)); },
         "PinType.PinCategory": (p: PinProperty, value: string) => { p.category = PinPropertyParser.parsePinCategory(value); },
+        "PinType": (p: PinProperty, value: string) => {
+            // UserDefinedPin format: PinType=(PinCategory="bool")
+            const categoryMatch = value.match(/PinCategory="([^"]+)"/);
+            if (categoryMatch) {
+                p.category = PinPropertyParser.parsePinCategory(`"${categoryMatch[1]}"`);
+            }
+        },
         "Direction": (p: PinProperty, value: string) => { p.direction = PinPropertyParser.parseDirection(value); },
         "DesiredPinDirection": (p: PinProperty, value: string) => { p.direction = PinPropertyParser.parseDirection(value); },
         "PinToolTip": (p: PinProperty, value: string) => { p.toolTip = BlueprintParserUtils.parseString(value); },
@@ -271,9 +278,11 @@ export class PinPropertyParser implements CustomPropertyParser {
             case PinCategory.bool:
                 return { control: CheckBoxControl, data: (BlueprintParserUtils.parseString(value).toLowerCase() === "true") };
             case PinCategory.struct:
-                return this.parseDefaultValueStruct(p.subCategoryObject.class, value);
+                if (p.subCategoryObject && p.subCategoryObject.class) {
+                    return this.parseDefaultValueStruct(p.subCategoryObject.class, value);
+                }
             case PinCategory.byte:
-                if (p.subCategoryObject.type === "Enum") {
+                if (p.subCategoryObject && p.subCategoryObject.type === "Enum") {
                     return { control: TextBoxControl, data: BlueprintParserUtils.parseEnumValue(p.subCategoryObject.class, value) };
                 } else {
                     return { control: TextBoxControl, data: BlueprintParserUtils.parseString(value) };
@@ -366,13 +375,15 @@ export class PinPropertyParser implements CustomPropertyParser {
                 p.defaultValue = "  ";
                 p.defaultValueControlClass = TextBoxControl;
             case PinCategory.struct:
-                switch (p.subCategoryObject.class) {
-                    case StructClass.VECTOR2D:
-                        p.defaultValue = [
-                            { key: 'X', value: '0.0' },
-                            { key: 'Y', value: '0.0' }];
-                        p.defaultValueControlClass = StructBoxControl;
-                        break;
+                if (p.subCategoryObject && p.subCategoryObject.class) {
+                    switch (p.subCategoryObject.class) {
+                        case StructClass.VECTOR2D:
+                            p.defaultValue = [
+                                { key: 'X', value: '0.0' },
+                                { key: 'Y', value: '0.0' }];
+                            p.defaultValueControlClass = StructBoxControl;
+                            break;
+                    }
                 }
                 break;
         }

--- a/src/parser/pin-property.parser.ts
+++ b/src/parser/pin-property.parser.ts
@@ -274,6 +274,7 @@ export class PinPropertyParser implements CustomPropertyParser {
 
         switch (p.category) {
             case PinCategory.float:
+            case PinCategory.real:
                 return { control: TextBoxControl, data: removeInsignificantTrailingZeros(BlueprintParserUtils.parseString(value)) };
             case PinCategory.bool:
                 return { control: CheckBoxControl, data: (BlueprintParserUtils.parseString(value).toLowerCase() === "true") };


### PR DESCRIPTION
Add parsing support for a few missing pin types

1. Add pin attribute parsers for:
  - `serializeAsSinglePrecisionFloat`
  - `subPins`
  - `parentPin`
  - `DesiredPinDirection`
2. Add node parser for `UserDefinedPin`
3. Add color and rounding support for the `real` pin type (make it green, same as `float`)
4. Handle `PinFriendlyName` for `INVTEXT`
5. Added several null checks on `subCategoryObject` to prevent `Uncaught TypeError: can't access property "class", i.subCategoryObject is undefined`. Without these several node and pin types do not display.


This patch removes a number of errors from the browser console like

```
Didn't parse property attribute 'PinType.bSerializeAsSinglePrecisionFloat'. There isn't a matching parser.
There is no implementation for custom property type 'UserDefinedPin'. Skip this property
```

**Tests:** I created one node for each of these pin types and verified that they display correctly.

**1) Nodes in Unreal:**
<img width="824" height="712" alt="klee pin types 1 - unreal" src="https://github.com/user-attachments/assets/7494a321-ad61-461c-bb6b-239256e835c5" />

**2) Before This Patch: Nodes in current main code**
(note you will need to add the null checks for this to render; otherwise it will not display)
<img width="884" height="741" alt="klee pin types 2 - before patch - current main code" src="https://github.com/user-attachments/assets/151b827d-f361-41e9-820c-874ffc89bb90" />

**3) After This Patch: Nodes display more correctly**
<img width="902" height="741" alt="klee pin types 3 - with patch" src="https://github.com/user-attachments/assets/fc68f29d-317d-4155-8474-8d9a8a255906" />

