### PR TITLE
Create 'plugin registry' system

### DIFF
--- a/src/parser/node-parser-registry.ts
+++ b/src/parser/node-parser-registry.ts
@@ -1,0 +1,90 @@
+import { UnrealNodeClass } from "../data/classes/unreal-node-class";
+import { NodeFriendlyNames } from "./node-friendly-names";
+import { NodeParser } from "./node.parser";
+
+/**
+ * Plugin interface for extending Klee with custom node parsers.
+ *
+ * To create a plugin
+ * ```typescript
+ *
+ * import {YourParser} from "./your.parsers";
+ *
+ * export const plugin: NodeParserPlugin = {
+ *     registerNodeParsers(): void {
+ *         const registry = NodeParserRegistry.getInstance();
+ *         registry.registerParser("/Script/Location.YourNodeClass", () => new YourParser());
+ *     },
+ *     nodeFriendlyNames: {
+ *         'YourNodeClass': 'Your Friendly Name'
+ *     }
+ * };
+ * ```
+ */
+export interface NodeParserPlugin {
+    registerNodeParsers: () => void;
+    nodeFriendlyNames: { [name: string]: string };
+}
+
+export class NodeParserRegistry {
+    public parsers: Map<UnrealNodeClass, () => NodeParser> = new Map();
+
+    private static instance: NodeParserRegistry;
+    private pluginsLoaded: boolean = false;
+
+    private constructor() {}
+
+    public static getInstance(): NodeParserRegistry {
+        if (!NodeParserRegistry.instance) {
+            NodeParserRegistry.instance = new NodeParserRegistry();
+        }
+        return NodeParserRegistry.instance;
+    }
+
+    public autoLoadPlugins(): void {
+        if (this.pluginsLoaded) return;
+
+        try {
+            this.loadPlugins();
+        } catch (error) {
+            console.error("Could not load plugins:", error);
+        }
+        this.pluginsLoaded = true;
+    }
+
+    private loadPlugins(): void {
+        const pluginContext = (require as any).context('../plugins', false, /\.ts$/);
+        const pluginPaths = pluginContext.keys();
+
+        pluginPaths.forEach((pluginPath: string) => {
+            try {
+                const plugin = pluginContext(pluginPath);
+
+                const registerParsers = plugin.plugin?.registerNodeParsers || plugin.registerNodeParsers;
+                const friendlyNames = plugin.plugin?.nodeFriendlyNames || plugin.nodeFriendlyNames;
+
+                if (!registerParsers || typeof registerParsers !== 'function') {
+                    return;
+                }
+
+                registerParsers();
+
+                if (friendlyNames && typeof friendlyNames === 'object') {
+                    for (const [key, value] of Object.entries(friendlyNames)) {
+                        NodeFriendlyNames[key] = value as string;
+                    }
+                }
+            } catch (error) {
+                console.error(`Error loading plugin ${pluginPath}:`, error);
+            }
+        });
+    }
+
+    public registerParser(nodeClass: string | UnrealNodeClass, parserFactory: () => NodeParser): void {
+        this.parsers.set(nodeClass as UnrealNodeClass, parserFactory);
+    }
+
+    public getParser(nodeClass: UnrealNodeClass): (() => NodeParser) | undefined {
+        return this.parsers.get(nodeClass);
+    }
+}

--- a/src/parser/node-parsers/generic-node.parser.ts
+++ b/src/parser/node-parsers/generic-node.parser.ts
@@ -36,6 +36,7 @@ import { SpawnActorNodeParser } from "./spawn-actor-node.parser";
 import { TunnelNodeParser } from "./tunnel-node.parser";
 import { CreateWidgetNodeParser } from "./create-widget-node.parser";
 import { CreateObjectNodeParser } from "./create-object-node.parser";
+import { NodeParserRegistry } from "../node-parser-registry";
 
 
 export class GenericNodeParser extends NodeParser {
@@ -98,6 +99,20 @@ export class GenericNodeParser extends NodeParser {
             "ErrorType": (node: Node, v: string) => { node.errorType = Number.parseInt(v); },
             "ErrorMsg": (node: Node, v: string) => { node.errorMsg = v.replace(/["]/g, '').replace(/\\\'/g, '\''); }
         });
+
+        const registry = NodeParserRegistry.getInstance();
+        for (const nodeClass of Object.values(UnrealNodeClass)) {
+            const pluginParser = registry.getParser(nodeClass);
+            if (pluginParser) {
+                this._nodeParsers[nodeClass] = pluginParser;
+            }
+        }
+
+        registry.autoLoadPlugins();
+
+        for (const [nodeClass, parserFactory] of registry.parsers) {
+            this._nodeParsers[nodeClass] = parserFactory;
+        }
     }
 
     public parse(data: ParsingNodeData): NodeControl {


### PR DESCRIPTION
Create a system that reads and adds parser classes from a 'plugin' folder.

This would allow anyone to add their own custom parser classes without having to edit the base library code.

..

**Use Case:** Say you are using the klee library to draw Blueprints on a web page. But you have some custom Unreal classes that you have added to your source code. You want to be able to draw and render these classes correctly using Klee. But klee doesn't know anything about your classes or code.

**Solution:** With this patch you can create your own custom klee parser classes inside a file in the `plugins/` directory.
Klee will then load in your parsers and use them to render and display your custom Unreal Blueprint classes.

So everything looks nice and tidy, and you can change or iterate on your own parser classes, without having to make edits to the main klee source code.

This would allow any team to simple maintain their own parser classes and put them into a folder, to display whatever they want.


I hope this idea will be useful for any team wanting to render their own classes.
I am open to feedback.