### PR TITLE
Add camera zoom

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -138,6 +138,24 @@ export class Application {
         return true;
     }
 
+    zoomIn() {
+        this._scene.camera.zoomIn();
+        this.refresh();
+        return true;
+    }
+
+    zoomOut() {
+        this._scene.camera.zoomOut();
+        this.refresh();
+        return true;
+    }
+
+    resetZoom() {
+        this._scene.camera.resetZoom();
+        this.refresh();
+        return true;
+    }
+
     static registerInstance(element: HTMLCanvasElement, app: Application) {
         element.setAttribute("data-klee-instance", Application.instances.length.toString());
         Application.instances.push(app);

--- a/src/application.ts
+++ b/src/application.ts
@@ -186,3 +186,9 @@ export class Application {
         return app;
     }
 }
+
+// Export Application to global scope for external controls
+if (window) {
+    (window as any).KleeApplication = Application;
+}
+

--- a/src/application.ts
+++ b/src/application.ts
@@ -189,6 +189,6 @@ export class Application {
 
 // Export Application to global scope for external controls
 if (window) {
-    (window as any).KleeApplication = Application;
+    window.KleeApplication = Application;
 }
 

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -26,6 +26,14 @@ export class Camera {
         this._zoom = Math.max(this._minZoom, Math.min(this._maxZoom, value));
     }
 
+    public get isAtMinZoom(): boolean {
+        return this._zoom <= this._minZoom;
+    }
+
+    public get isAtMaxZoom(): boolean {
+        return this._zoom >= this._maxZoom;
+    }
+
     prepareViewport() {
         this._canvas.translate(Math.round(this._position.x), Math.round(this._position.y));
         this._canvas.scale(this._zoom, this._zoom);

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -5,6 +5,9 @@ export class Camera {
 
     private _canvas: Canvas2D;
     private _position: Vector2;
+    private _zoom: number = 1.0;
+    private _minZoom: number = 0.5;
+    private _maxZoom: number = 2.0;
 
     constructor(canvas: Canvas2D) {
         this._canvas = canvas;
@@ -15,8 +18,17 @@ export class Camera {
         return this._position;
     }
 
+    public get zoom(): number {
+        return this._zoom;
+    }
+
+    public set zoom(value: number) {
+        this._zoom = Math.max(this._minZoom, Math.min(this._maxZoom, value));
+    }
+
     prepareViewport() {
         this._canvas.translate(Math.round(this._position.x), Math.round(this._position.y));
+        this._canvas.scale(this._zoom, this._zoom);
     }
 
     moveRelative(value: Vector2) {
@@ -24,9 +36,36 @@ export class Camera {
     }
 
     centerAbsolutePosition(value: Vector2) {
-
         this._position = new Vector2(
             Math.round(value.x + this._canvas.width / 2),
             Math.round(value.y + this._canvas.height / 2));
+    }
+
+    zoomIn(factor: number = 1.2) {
+        const centerX = this._canvas.width / 2;
+        const centerY = this._canvas.height / 2;
+        this.zoomAtPoint(factor, centerX, centerY);
+    }
+
+    zoomOut(factor: number = 0.8) {
+        const centerX = this._canvas.width / 2;
+        const centerY = this._canvas.height / 2;
+        this.zoomAtPoint(factor, centerX, centerY);
+    }
+
+    private zoomAtPoint(factor: number, centerX: number, centerY: number) {
+        const oldZoom = this._zoom;
+        this.zoom = this._zoom * factor;
+        const actualFactor = this._zoom / oldZoom;
+
+        // Adjust position so zoom appears centered at the specified point
+        const offsetX = (centerX - this._position.x) * (1 - actualFactor);
+        const offsetY = (centerY - this._position.y) * (1 - actualFactor);
+
+        this._position = this._position.add(new Vector2(offsetX, offsetY));
+    }
+
+    resetZoom() {
+        this._zoom = 1.0;
     }
 }

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -126,6 +126,11 @@ export class Canvas2D {
         return this;
     }
 
+    scale(x: number, y: number) {
+        this._context.scale(x, y);
+        return this;
+    }
+
     fillRect(x: number, y: number, width: number, height: number) {
         this._context.fillRect(x, y, width, height);
         return this;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Type definitions for window globals
+ */
+
+import { Application } from '../application';
+
+declare global {
+    interface Window {
+        KleeApplication: typeof Application;
+    }
+}
+
+export {};
+


### PR DESCRIPTION
Hello - What do you think about exposing some library functions to move and adjust the canvas, for easier viewing?

**My use case:** We work with some Unreal Blueprints + Event Graphs that are quite large - 100+ nodes and screenshots that are 15,000 pixels tall or wide, or more.

klee is excellent at helping us better display these sizes of Blueprint.
But it would *also* be helpful to be able to quickly move around and view different parts of the canvas.

This PR proposes adding a few methods to expose klee camera behaviour:

```typescript
zoomIn()
zoomOut()
resetZoom()
```

This makes it easy to add some javascript UI controls in the HTML page to let the reader easily move around and zoom.
e.g. I can add some javascript like

```javascript
const canvas = document.getElementById(canvasId); // each klee canvas on the page gets a UUID

if (canvas && window && window.KleeApplication && window.KleeApplication.getInstance) {
  app = window.KleeApplication.getInstance(canvas);
}

...

app.resetZoom();
app.zoomIn();
app.zoomOut();
```

With some buttons:

<img width="403" height="43" alt="klee - zoom control ui buttons" src="https://github.com/user-attachments/assets/3e7617eb-fd5c-45cc-a697-197b817e89d8" />


Do you often use klee to work with large Blueprints like this?

**Tests:**

- Can manually move the canvas around with the right mouse to view nodes (same as normal)
- Can click some 'zoom in' and 'zoom out' buttons to call these exposed methods, and zoom the canvas
